### PR TITLE
Add documentation for RobStride MotorStudio language configuration

### DIFF
--- a/hardware_assets/robots/unitree_quadruped/software_and_drivers/RobStride/robstride_motorstudio_config_notes.md
+++ b/hardware_assets/robots/unitree_quadruped/software_and_drivers/RobStride/robstride_motorstudio_config_notes.md
@@ -1,0 +1,25 @@
+# RobStride MotorStudio Configuration Notes
+
+## Software Source
+
+The RobStride MotorStudio software can be downloaded from their official GitHub releases page:
+[https://github.com/RobStride/MotorStudio/releases/tag/V0.0.8](https://github.com/RobStride/MotorStudio/releases/tag/V0.0.8)
+
+## Language Configuration
+
+To change the MotorStudio software language from Chinese to English, you need to modify its configuration file.
+
+1.  **Locate the Configuration File:**
+    *   The exact location of this file may vary depending on where you installed the MotorStudio software on your system.
+    *   Look for a configuration file typically ending in `.ini`, `.conf`, `.json`, `.yaml`, or similar, within the MotorStudio installation directory. Common installation paths include `C:\Program Files\MotorStudio` or `~/Applications/MotorStudio` or similar.
+
+2.  **Edit the Language Setting:**
+    *   Open the configuration file in a text editor.
+    *   Look for a line similar to `language = zh_CN` or `language: zh_CN`.
+    *   Change this line to `language = en_US` or `language: en_US` to set the language to English.
+    *   Save the configuration file.
+
+3.  **Restart MotorStudio:**
+    *   After saving the changes, restart the MotorStudio software for the new language setting to take effect.
+
+**Note:** This document assumes the configuration process based on the information provided. The exact name and location of the configuration file and the language parameter might differ slightly. Always refer to any official documentation from RobStride if available.


### PR DESCRIPTION
This commit introduces a new markdown file, `robstride_motorstudio_config_notes.md`, located under `hardware_assets/robots/unitree_quadruped/software_and_drivers/RobStride/`.

The file contains instructions on:
- Where to download the RobStride MotorStudio software.
- How to locate and modify its configuration file to change the display language from Chinese (zh_CN) to English (en_US).

This documentation is based on information you provided regarding new RobStride motors and their associated software.