### PR TITLE
Docs: Update club website status and add new domain

### DIFF
--- a/robotics_club/club_setup_and_infrastructure.md
+++ b/robotics_club/club_setup_and_infrastructure.md
@@ -11,9 +11,11 @@ This document tracks key setup tasks and infrastructure decisions for the roboti
         - TinSoul.ca
         - RobotClub.cc
         - robotclub.top
+        - robotclub.to
     - **Hosting Provider:**
-        - An account has been set up with IONOS for these domains and potential website hosting.
-    - **To-Do:** Plan and develop website content for the chosen domain(s).
+        - An account has been set up with IONOS (ionos.ca) for these domains and website hosting. All listed domains will have a basic webpage added and are hosted here.
+    - **Status:** A rough draft of a basic webpage has been posted publicly.
+    - **To-Do:** Continue to refine and develop website content.
 
 ## Communication & Collaboration
 


### PR DESCRIPTION
Reflects recent updates to the robotics club's online presence:
- Adds `robotclub.to` to the list of registered domains.
- Updates the website development status to indicate that a rough draft is now publicly posted.
- Clarifies that all listed domains (TinSoul.ca, RobotClub.cc, RobotClub.top, robotclub.to) are hosted at IONOS (ionos.ca) and will feature a basic webpage.

These changes are in `robotics_club/club_setup_and_infrastructure.md`.